### PR TITLE
feat: colorize rfc7807 error repsonses

### DIFF
--- a/output/pretty.go
+++ b/output/pretty.go
@@ -133,7 +133,7 @@ func isJSON(contentType string) bool {
 		contentType = contentType[:semicolon]
 	}
 
-	return contentType == "application/json"
+	return contentType == "application/json" || strings.HasSuffix(contentType, "+json")
 }
 
 func (p *PrettyPrinter) PrintBody(body io.Reader, contentType string) error {

--- a/output/pretty_test.go
+++ b/output/pretty_test.go
@@ -135,3 +135,14 @@ func TestPrettyPrinter_PrintBody(t *testing.T) {
 		t.Errorf("unexpected output: expected=\n%s\nactual=\n%s\n", expected, buffer.String())
 	}
 }
+
+func TestPrettyPrinter_DetectJSON(t *testing.T) {
+	if !isJSON("application/json") {
+		t.Errorf("didn't detect application/json as JSON")
+	}
+
+	// See https://tools.ietf.org/html/rfc7807
+	if !isJSON("application/problem+json") {
+		t.Errorf("didn't detect application/problem+json as JSON")
+	}
+}


### PR DESCRIPTION
This adds color pretty-printing support for [RFC 7807](https://tools.ietf.org/html/rfc7807) error responses that use `application/problem+json` as the content type.

See also [RFC 6839 §3.1](https://tools.ietf.org/html/rfc6839#section-3.1) which defines the general `+json` suffix.

Thanks for making this awesome tool!