### PR TITLE
fix dns issue under termux and make it static;

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 EXE_NAME=ht
 
 build:
+	go build -o $(EXE_NAME) ./cmd/ht
+
+build-termux:
 	env CGO_ENABLED=0 go build -o $(EXE_NAME) -tags='androiddnsfix' ./cmd/ht
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EXE_NAME=ht
 
 build:
-	go build -o $(EXE_NAME) ./cmd/ht
+	env CGO_ENABLED=0 go build -o $(EXE_NAME) -tags='androiddnsfix' ./cmd/ht
 
 install:
 	go install ./cmd/ht

--- a/README.md
+++ b/README.md
@@ -59,3 +59,9 @@ Note that some minor options are yet to be implemented in httpie-go.
 ```
 make
 ```
+
+For non-standard Linux system like Android [termux](https://termux.com/), use following method to avoid the DNS issue.
+
+```
+make build-termux
+```

--- a/androiddnsfix.go
+++ b/androiddnsfix.go
@@ -1,0 +1,5 @@
+package httpie
+
+// +build androiddnsfix
+
+import _ "github.com/mtibben/androiddnsfix"

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48
 	github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381
 	github.com/mattn/go-isatty v0.0.12
+	github.com/mtibben/androiddnsfix v0.0.0-20200907095054-ff0280446354
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
 	github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381 h1:bqDmpDG49ZRn
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mtibben/androiddnsfix v0.0.0-20200907095054-ff0280446354 h1:aS4S9U7xE7bwYB6gn/X0BteBAasVEfQwPV5k8trGXW4=
+github.com/mtibben/androiddnsfix v0.0.0-20200907095054-ff0280446354/go.mod h1:Cu3Rcze2YUpuTWfggCBafY8U9/ckCksdAiONQ7XDvB8=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httputil"
 	"os"
 
-	_ "github.com/mtibben/androiddnsfix"
 	"github.com/nojima/httpie-go/exchange"
 	"github.com/nojima/httpie-go/flags"
 	"github.com/nojima/httpie-go/input"

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httputil"
 	"os"
 
+	_ "github.com/mtibben/androiddnsfix"
 	"github.com/nojima/httpie-go/exchange"
 	"github.com/nojima/httpie-go/flags"
 	"github.com/nojima/httpie-go/input"


### PR DESCRIPTION
For system like Termux without standard /etc/resolve.conf golang program can run into DNS issue. The fix set default DNS other than [::1] to fix the issue. Feel free to adapt the fix like making it a separate Make rule. 