### PR TITLE
MainWithOptions to allow overriding transport.

### DIFF
--- a/cmd/ht/main.go
+++ b/cmd/ht/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	if err := httpie.Main(); err != nil {
+	if err := httpie.Main(&httpie.Options{}); err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 		os.Exit(1)
 	}

--- a/exchange/client.go
+++ b/exchange/client.go
@@ -14,17 +14,21 @@ func BuildHTTPClient(options *Options) (*http.Client, error) {
 		checkRedirect = nil
 	}
 
-	transp := http.DefaultTransport.(*http.Transport).Clone()
-	transp.TLSClientConfig.InsecureSkipVerify = options.SkipVerify
-	if options.ForceHTTP1 {
-		transp.TLSClientConfig.NextProtos = []string{"http/1.1", "http/1.0"}
-		transp.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
-	}
-
 	client := http.Client{
 		CheckRedirect: checkRedirect,
 		Timeout:       options.Timeout,
-		Transport:     transp,
+	}
+
+	if options.Transport == nil {
+		transp := http.DefaultTransport.(*http.Transport).Clone()
+		transp.TLSClientConfig.InsecureSkipVerify = options.SkipVerify
+		if options.ForceHTTP1 {
+			transp.TLSClientConfig.NextProtos = []string{"http/1.1", "http/1.0"}
+			transp.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
+		}
+		client.Transport = transp
+	} else {
+		client.Transport = options.Transport
 	}
 
 	return &client, nil

--- a/exchange/client.go
+++ b/exchange/client.go
@@ -19,16 +19,18 @@ func BuildHTTPClient(options *Options) (*http.Client, error) {
 		Timeout:       options.Timeout,
 	}
 
+	var transp http.RoundTripper
 	if options.Transport == nil {
-		transp := http.DefaultTransport.(*http.Transport).Clone()
-		transp.TLSClientConfig.InsecureSkipVerify = options.SkipVerify
-		if options.ForceHTTP1 {
-			transp.TLSClientConfig.NextProtos = []string{"http/1.1", "http/1.0"}
-			transp.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
-		}
-		client.Transport = transp
+		transp = http.DefaultTransport.(*http.Transport).Clone()
 	} else {
-		client.Transport = options.Transport
+		transp = options.Transport
+	}
+	if httpTransport, ok := transp.(*http.Transport); ok {
+		httpTransport.TLSClientConfig.InsecureSkipVerify = options.SkipVerify
+		if options.ForceHTTP1 {
+			httpTransport.TLSClientConfig.NextProtos = []string{"http/1.1", "http/1.0"}
+			httpTransport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
+		}
 	}
 
 	return &client, nil

--- a/exchange/options.go
+++ b/exchange/options.go
@@ -1,6 +1,9 @@
 package exchange
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 type Options struct {
 	Timeout         time.Duration
@@ -9,6 +12,7 @@ type Options struct {
 	SkipVerify      bool
 	ForceHTTP1      bool
 	CheckStatus     bool
+	Transport       http.RoundTripper
 }
 
 type AuthOptions struct {

--- a/main.go
+++ b/main.go
@@ -15,15 +15,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Main() error {
-	return MainWithOptions(&Options{})
-}
-
 type Options struct {
 	Transport http.RoundTripper
 }
 
-func MainWithOptions(options *Options) error {
+func Main(options *Options) error {
 	// Parse flags
 	args, usage, optionSet, err := flags.Parse(os.Args)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@ import (
 )
 
 type Options struct {
+	// Transport is applied to the underlying HTTP client. Use to mock or
+	// intercept network traffic.  If nil, http.DefaultTransport will be cloned.
 	Transport http.RoundTripper
 }
 

--- a/main.go
+++ b/main.go
@@ -16,6 +16,14 @@ import (
 )
 
 func Main() error {
+	return MainWithOptions(&Options{})
+}
+
+type Options struct {
+	Transport http.RoundTripper
+}
+
+func MainWithOptions(options *Options) error {
 	// Parse flags
 	args, usage, optionSet, err := flags.Parse(os.Args)
 	if err != nil {
@@ -23,6 +31,7 @@ func Main() error {
 	}
 	inputOptions := optionSet.InputOptions
 	exchangeOptions := optionSet.ExchangeOptions
+	exchangeOptions.Transport = options.Transport
 	outputOptions := optionSet.OutputOptions
 
 	// Parse positional arguments


### PR DESCRIPTION
Hello! First, I wanted to say thank you for your lovely clone of HTTPie.

Second, I'd like to contribute this small patch which I had to make in order to implement my own little thing: https://github.com/deref/pier

This PR introduces a function `MainWithOptions` that takes one new option: `Transport`, which allows you to override the `http.RoundTripper` instance used as part of the `http.Client`. Making this dependency injectable allowed me to use httpie-go as a library against an in-memory `http.Handler` using `httptest.ResponseRecorder`. For details, see https://github.com/deref/pier/blob/ae2d5cdd8f2f36ef7d186b19a9661a56ba926cae/main.go

If for some reason this patch is not acceptable as is, but some form of this change would be, let me know and I'm happy to make adjustments. Otherwise, I'm happy to maintain a fork as long as needed.

Thanks!
- Brandon