### PR TITLE
Fixup dropped line from PR #70

### DIFF
--- a/exchange/client.go
+++ b/exchange/client.go
@@ -32,6 +32,7 @@ func BuildHTTPClient(options *Options) (*http.Client, error) {
 			httpTransport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
 		}
 	}
+	client.Transport = transp
 
 	return &client, nil
 }


### PR DESCRIPTION
Hi @nojima, I'm just now getting around to removing the `replace` directive from my go.mod file and I realized that in the shuffle of the code review feedback on #70, I somehow dropped this critical line of code! Without this, the feature doesn't work at all :) Please merge. Apologies for the noise. Thank you!